### PR TITLE
[TASK] Dynamic routing configuration

### DIFF
--- a/Configuration/Routes.yaml
+++ b/Configuration/Routes.yaml
@@ -1,10 +1,14 @@
 # Google Sitemap Route
 -
   name:  'Google Sitemap'
-  uriPattern: '<sitemapBaseUri>sitemap.xml'
+  uriPattern: '{node}<sitemapBaseUri>sitemap.xml'
   defaults:
-    'node':        '<rootNodePath>'
     '@package':    'TYPO3.Neos'
     '@controller': 'Frontend\Node'
     '@action':     'show'
     '@format':     'xml'
+  routeParts:
+    'node':
+      handler: 'TYPO3\Neos\Routing\FrontendNodeRoutePartHandlerInterface'
+      options:
+        onlyMatchSiteNodes: TRUE


### PR DESCRIPTION
Instead of having to provide a site node path, the route should just respond to all sites.

This also removes the dependency on the unmerged Flow feature.
